### PR TITLE
update dockerfile to newer ubuntu/python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:cosmic
+FROM ubuntu:focal
 
 
 # Requirements
@@ -11,7 +11,7 @@ CMD ["iptables-exporter"]
 
 # Source
 COPY iptables-exporter /usr/local/bin/iptables-exporter
-COPY iptables_exporter /usr/local/lib/python3.6/dist-packages/iptables_exporter
+COPY iptables_exporter /usr/local/lib/python3.8/dist-packages/iptables_exporter
 
 RUN    chmod 0755 /usr/local/bin/iptables-exporter \
-    && python3 -m compileall /usr/local/lib/python3.6/dist-packages/iptables_exporter
+    && python3 -m compileall /usr/local/lib/python3.8/dist-packages/iptables_exporter


### PR DESCRIPTION
Fixes the following error while running with newish iptables versions and hashlimit module used in exported rules

`Traceback (most recent call last):
  File "/usr/local/bin/iptables-exporter", line 6, in <module>
    main()
  File "/usr/local/lib/python3.6/dist-packages/iptables_exporter/main.py", line 134, in main
    dump_data(args.ip_versions, args.tables)
  File "/usr/local/lib/python3.6/dist-packages/iptables_exporter/main.py", line 99, in dump_data
    collect_metrics(ip_versions, tables)
  File "/usr/local/lib/python3.6/dist-packages/iptables_exporter/main.py", line 70, in collect_metrics
    exporter_name = get_exporter_name(rule)
  File "/usr/local/lib/python3.6/dist-packages/iptables_exporter/main.py", line 90, in get_exporter_name
    if 'comment' in match.parameters:
  File "/usr/lib/python3/dist-packages/iptc/ip4tc.py", line 461, in __getattr__
    return self.save(name.replace("_", "-"))
  File "/usr/lib/python3/dist-packages/iptc/ip4tc.py", line 377, in save
    return self._save(name, self.rule.get_ip())
  File "/usr/lib/python3/dist-packages/iptc/ip4tc.py", line 380, in _save
    buf = self._get_saved_buf(ip).decode()
AttributeError: 'NoneType' object has no attribute 'decode'`