### PR TITLE
Allow tracking rules that do not start with iptables-exporter

### DIFF
--- a/iptables_exporter/main.py
+++ b/iptables_exporter/main.py
@@ -20,7 +20,7 @@ TABLES = dict(
 IP_VERSION_CHOICES = ['4', '6']
 TABLE_CHOICES = TABLES.keys()
 DEFAULT_TABLE_CHOICES = ['filter']
-RE = re.compile('^iptables-exporter (?P<name>.*)$')
+RE = re.compile('iptables-exporter (?P<name>.*)$')
 
 
 class IptablesCollector(object):

--- a/iptables_exporter/main.py
+++ b/iptables_exporter/main.py
@@ -20,7 +20,7 @@ TABLES = dict(
 IP_VERSION_CHOICES = ['4', '6']
 TABLE_CHOICES = TABLES.keys()
 DEFAULT_TABLE_CHOICES = ['filter']
-RE = re.compile('iptables-exporter (?P<name>.*)$')
+RE = re.compile('(.*)?iptables-exporter (?P<name>.*)$')
 
 
 class IptablesCollector(object):


### PR DESCRIPTION
As I'm currently managing iptables rules with an Ansible module which automatically prepends some string into the iptables rule, it would be great allowing the exporter to pick up on these rules.